### PR TITLE
HB-193 - Adds Docker build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,6 +352,8 @@ jobs:
                     tags: ${{ steps.meta.outputs.tags }}
                     labels: ${{ steps.meta.outputs.labels }}
                     platforms: ${{ env.DOCKER_PLATFORMS }}
+                    cache-from: type=gha
+                    cache-to: type=gha,mode=max
                     build-args: |
                         FRONTEND_APPSETTINGS_FILE=${{ env.FRONTEND_APPSETTINGS_FILE }}
                         BACKEND_APPSETTINGS_FILE=${{ env.BACKEND_APPSETTINGS_FILE }}


### PR DESCRIPTION
Enables GitHub Actions cache for Docker builds to improve build performance by caching layers between runs and maximizing cache usage

Relates to HB-193