### PR TITLE
HB-238 - type: Add website release synchronization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ env:
     CLIENT_CLASS: "BackendClient"
     UNIT_TEST_CSPROJ: "./source/HomeBook.UnitTests/HomeBook.UnitTests.csproj"
     E2E_TEST_CSPROJ: "./source/HomeBook.E2ETests/HomeBook.E2ETests.csproj"
+    WEBSITE_REPOSITORY: "homebook-app/homebook-app.github.io"
+    WEBSITE_REPO_PATH: "./website-repo"
+    WEBSITE_RELEASES_MARKDOWN_DIR: "app/content/releases"
+    WEBSITE_RELEASES_JSON_FILE: "app/content/releases/releases.json"
 
 jobs:
 
@@ -359,3 +363,120 @@ jobs:
                     build-args: |
                         FRONTEND_APPSETTINGS_FILE=${{ env.FRONTEND_APPSETTINGS_FILE }}
                         BACKEND_APPSETTINGS_FILE=${{ env.BACKEND_APPSETTINGS_FILE }}
+
+    website-release-sync:
+        runs-on: ubuntu-latest
+        needs:
+            - client-deploy
+            - docker-deploy
+
+        steps:
+            -   name: Git checkout
+                uses: actions/checkout@v4
+                with:
+                    repository: ${{ env.WEBSITE_REPOSITORY }}
+                    token: ${{ secrets.WEBSITE_REPO_TOKEN }}
+                    path: ${{ env.WEBSITE_REPO_PATH }}
+                    clean: true
+
+            -   name: Configure Git User
+                working-directory: ${{ env.WEBSITE_REPO_PATH }}
+                run: |
+                    git config user.name "GitHub Actions"
+                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            -   name: Create release markdown
+                shell: bash
+                run: |
+                    set -euo pipefail
+
+                    release_date="$(date -u +%Y%m%d)"
+                    release_date_iso="$(date -u +%F)"
+                    short_sha="${GITHUB_SHA:0:7}"
+                    release_title="Homebook ${VERSION}"
+                    tag_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${VERSION}"
+                    commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+                    run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                    markdown_relative_path="${WEBSITE_RELEASES_MARKDOWN_DIR}/${release_date}-${VERSION}.md"
+                    markdown_absolute_path="${WEBSITE_REPO_PATH}/${markdown_relative_path}"
+
+                    mkdir -p "$(dirname "$markdown_absolute_path")"
+
+                    cat > "$markdown_absolute_path" <<EOF
+                    # ${release_title}
+
+                    - Date: ${release_date_iso}
+                    - Version: ${VERSION}
+                    - Commit: [\`${short_sha}\`](${commit_url})
+                    - Workflow Run: [#${GITHUB_RUN_ID}](${run_url})
+                    - Docker Image: \`${DOCKER_IMAGE}:${VERSION}\`
+
+                    ## Artifacts
+
+                    - Git tag: [\`${VERSION}\`](${tag_url})
+                    - Docker image: \`${DOCKER_IMAGE}:${VERSION}\`
+
+                    ## Notes
+
+                    This file was created automatically by \`.github/workflows/build.yml\`.
+                    EOF
+
+            -   name: Add markdown path and release to json-file
+                shell: bash
+                run: |
+                    set -euo pipefail
+
+                    release_date="$(date -u +%Y%m%d)"
+                    release_date_iso="$(date -u +%F)"
+                    release_title="Homebook ${VERSION}"
+                    tag_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${VERSION}"
+                    commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+                    run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                    markdown_relative_path="${WEBSITE_RELEASES_MARKDOWN_DIR}/${release_date}-${VERSION}.md"
+                    json_absolute_path="${WEBSITE_REPO_PATH}/${WEBSITE_RELEASES_JSON_FILE}"
+
+                    mkdir -p "$(dirname "$json_absolute_path")"
+
+                    if [ ! -f "$json_absolute_path" ]; then
+                      echo "[]" > "$json_absolute_path"
+                    fi
+
+                    entry_json="$(jq -n \
+                      --arg version "$VERSION" \
+                      --arg date "$release_date_iso" \
+                      --arg title "$release_title" \
+                      --arg markdownPath "$markdown_relative_path" \
+                      --arg tagUrl "$tag_url" \
+                      --arg commitUrl "$commit_url" \
+                      --arg runUrl "$run_url" \
+                      --arg dockerImage "${DOCKER_IMAGE}:${VERSION}" \
+                      '{
+                        version: $version,
+                        date: $date,
+                        title: $title,
+                        markdownPath: $markdownPath,
+                        tagUrl: $tagUrl,
+                        commitUrl: $commitUrl,
+                        runUrl: $runUrl,
+                        dockerImage: $dockerImage
+                      }')"
+
+                    tmp_file="$(mktemp)"
+                    jq --arg version "$VERSION" --argjson entry "$entry_json" '
+                      (if type == "array" then . else [] end)
+                      | map(select(.version != $version))
+                      | [$entry] + .
+                    ' "$json_absolute_path" > "$tmp_file"
+                    mv "$tmp_file" "$json_absolute_path"
+
+            -   name: Commit changes
+                working-directory: ${{ env.WEBSITE_REPO_PATH }}
+                run: |
+                    if [ -z "$(git status --short)" ]; then
+                      echo "No website release changes detected."
+                      exit 0
+                    fi
+
+                    git add ${{ env.WEBSITE_RELEASES_MARKDOWN_DIR }} ${{ env.WEBSITE_RELEASES_JSON_FILE }}
+                    git commit -m "Add release ${{ env.VERSION }}"
+                    git push


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to automatically synchronize release information with the website repository. It creates markdown files for each release containing version details, commit information, and artifact links, and updates a JSON file to track all releases. The workflow runs after client and docker deployments complete.